### PR TITLE
Add PaymentSplitter contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "keccak256": "^1.0.6",
     "merkletreejs": "^0.3.9",
     "solhint": "^3.4.1",
-    "solidity-coverage": "^0.8.2",
+    "solidity-coverage": "^0.8.5",
     "ts-node": "^10.9.1",
     "typechain": "^8.1.0",
     "typescript": "^4.9.5"

--- a/scripts/deploy-payment-splitter-implementation.ts
+++ b/scripts/deploy-payment-splitter-implementation.ts
@@ -1,0 +1,28 @@
+import { ethers } from "hardhat";
+
+async function main() {
+    const [deployer] = await ethers.getSigners();
+    console.log(
+        "🔥 Deploying PaymentSplitterImplementation with the account: ",
+        deployer.address,
+    );
+
+    const PaymentSplitterImplementation = await ethers.getContractFactory(
+        "PaymentSplitterImplementation",
+    );
+    const implementation = await PaymentSplitterImplementation.deploy();
+    await implementation.deployed();
+    await implementation.initialize([ethers.constants.AddressZero], [10000]);
+
+    console.log(
+        "🚀 PaymentSplitterImplementation deployed to: ",
+        implementation.address,
+    );
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/scripts/deploy-payment-splitter-proxy.ts
+++ b/scripts/deploy-payment-splitter-proxy.ts
@@ -1,0 +1,27 @@
+import { ethers } from "hardhat";
+
+async function main() {
+    const [deployer] = await ethers.getSigners();
+    console.log(
+        "🔥 Deploying PaymentSplitterProxy with the account: ",
+        deployer.address,
+    );
+
+    const PaymentSplitterProxy = await ethers.getContractFactory(
+        "PaymentSplitterProxy",
+    );
+    const proxy = await PaymentSplitterProxy.deploy(
+        [ethers.constants.AddressZero],
+        [10000],
+    );
+    await proxy.deployed();
+
+    console.log("🚀 PaymentSplitterProxy deployed to: ", proxy.address);
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((error) => {
+        console.error(error);
+        process.exit(1);
+    });

--- a/src/PaymentSplitterImplementation.sol
+++ b/src/PaymentSplitterImplementation.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+contract PaymentSplitterImplementation is Initializable {
+    using SafeERC20 for IERC20;
+
+    uint256 private constant PERCENTAGE_DENOMINATOR = 10_000;
+
+    address[] private _recipients;
+    mapping(address recipient => uint256 percentage) private _percentages;
+
+    uint256 private _totalEthReleased;
+    mapping(address recipient => uint256 amount) private _ethReleased;
+
+    mapping(IERC20 token => uint256 amount) private _totalErc20Released;
+    mapping(IERC20 token => mapping(address recipient => uint256 amount)) private _erc20Released;
+
+    error EmptyOrMismatchedArrays();
+    error InvalidPercentageAmount();
+    error DuplicateRecipient();
+    error NoFundsToRelease();
+    error InvalidRecipient();
+    error TransferFailed();
+
+    function initialize(
+        address[] calldata recipients,
+        uint256[] calldata percentages
+    ) external initializer {
+        if (recipients.length == 0 || recipients.length != percentages.length) {
+            revert EmptyOrMismatchedArrays();
+        }
+
+        uint256 totalPercentage;
+        for (uint256 i = 0; i < percentages.length; ) {
+            if (percentages[i] == 0) revert InvalidPercentageAmount();
+            if (_percentages[recipients[i]] != 0) revert DuplicateRecipient();
+
+            _recipients.push(recipients[i]);
+            _percentages[recipients[i]] = percentages[i];
+
+            totalPercentage += percentages[i];
+
+            unchecked {
+                ++i;
+            }
+        }
+
+        if (totalPercentage != PERCENTAGE_DENOMINATOR) {
+            revert InvalidPercentageAmount();
+        }
+    }
+
+    function releaseEth(address payable recipient) external {
+        if (_percentages[recipient] == 0) revert InvalidRecipient();
+
+        uint256 amount = calculateReleasableEth(recipient);
+        if (amount == 0) revert NoFundsToRelease();
+
+        _totalEthReleased += amount;
+        unchecked {
+            _ethReleased[recipient] += amount;
+        }
+
+        (bool success, ) = recipient.call{value: amount}("");
+        if (!success) revert TransferFailed();
+    }
+
+    function releaseErc20(IERC20 token, address recipient) external {
+        if (_percentages[recipient] == 0) revert InvalidRecipient();
+
+        uint256 amount = calculateReleasableErc20(token, recipient);
+        if (amount == 0) revert NoFundsToRelease();
+
+        _totalErc20Released[token] += amount;
+        unchecked {
+            _erc20Released[token][recipient] += amount;
+        }
+
+        token.safeTransfer(recipient, amount);
+    }
+
+    function calculateReleasableEth(
+        address recipient
+    ) public view returns (uint256) {
+        uint256 totalReceived = address(this).balance + _totalEthReleased;
+
+        uint256 amount = _calculateReleasableAmount(
+            recipient,
+            totalReceived,
+            _ethReleased[recipient]
+        );
+
+        return amount;
+    }
+
+    function calculateReleasableErc20(
+        IERC20 token,
+        address recipient
+    ) public view returns (uint256) {
+        uint256 totalReceived = token.balanceOf(address(this)) +
+            _totalErc20Released[token];
+
+        uint256 amount = _calculateReleasableAmount(
+            recipient,
+            totalReceived,
+            _erc20Released[token][recipient]
+        );
+
+        return amount;
+    }
+
+    function _calculateReleasableAmount(
+        address recipient,
+        uint256 totalReceived,
+        uint256 alreadyReleased
+    ) internal view returns (uint256) {
+        uint256 amount = (totalReceived * _percentages[recipient]) /
+            PERCENTAGE_DENOMINATOR -
+            alreadyReleased;
+
+        return amount;
+    }
+}

--- a/src/PaymentSplitterImplementation.sol
+++ b/src/PaymentSplitterImplementation.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.18;
 
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";

--- a/src/PaymentSplitterImplementation.sol
+++ b/src/PaymentSplitterImplementation.sol
@@ -68,11 +68,12 @@ contract PaymentSplitterImplementation is Initializable {
     }
 
     function releaseEthToAll() external {
-        for (uint256 i = 0; i < _recipients.length; ++i) {
-            uint256 amount = calculateReleasableEth(_recipients[i]);
+        address[] memory recipients = _recipients;
+        for (uint256 i = 0; i < recipients.length; ++i) {
+            uint256 amount = calculateReleasableEth(recipients[i]);
             if (amount == 0) continue;
 
-            _releaseEth(_recipients[i], amount);
+            _releaseEth(recipients[i], amount);
         }
     }
 
@@ -86,11 +87,12 @@ contract PaymentSplitterImplementation is Initializable {
     }
 
     function releaseErc20ToAll(IERC20 token) external {
-        for (uint256 i = 0; i < _recipients.length; ++i) {
-            uint256 amount = calculateReleasableErc20(token, _recipients[i]);
+        address[] memory recipients = _recipients;
+        for (uint256 i = 0; i < recipients.length; ++i) {
+            uint256 amount = calculateReleasableErc20(token, recipients[i]);
             if (amount == 0) continue;
 
-            _releaseErc20(token, _recipients[i], amount);
+            _releaseErc20(token, recipients[i], amount);
         }
     }
 

--- a/src/PaymentSplitterImplementation.sol
+++ b/src/PaymentSplitterImplementation.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.18;
 
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 contract PaymentSplitterImplementation is Initializable {
     using SafeERC20 for IERC20;
@@ -25,6 +25,8 @@ contract PaymentSplitterImplementation is Initializable {
     error NoFundsToRelease();
     error InvalidRecipient();
     error TransferFailed();
+
+    receive() external payable {}
 
     function initialize(
         address[] calldata recipients,

--- a/src/PaymentSplitterProxy.sol
+++ b/src/PaymentSplitterProxy.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import "@openzeppelin/contracts/proxy/Proxy.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/utils/StorageSlot.sol";
+
+contract PaymentSplitterProxy is Proxy {
+    constructor(
+        address[] memory recipients,
+        uint256[] memory percentages
+    ) {
+        assert(
+            _IMPLEMENTATION_SLOT ==
+                bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)
+        );
+        StorageSlot
+            .getAddressSlot(_IMPLEMENTATION_SLOT)
+            .value = 0xafA3348dE7D6C93E6e0142c15d520F33898F14C8;
+        Address.functionDelegateCall(
+            0xafA3348dE7D6C93E6e0142c15d520F33898F14C8,
+            abi.encodeWithSignature(
+                "initialize(address[],uint256[])",
+                recipients,
+                percentages
+            )
+        );
+    }
+
+    /**
+     * @dev Storage slot with the address of the current implementation.
+     * This is the keccak-256 hash of "eip1967.proxy.implementation" subtracted by 1, and is
+     * validated in the constructor.
+     */
+    bytes32 internal constant _IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    /**
+     * @dev Returns the current implementation address.
+     */
+    function implementation() public view returns (address) {
+        return _implementation();
+    }
+
+    function _implementation() internal view override returns (address) {
+        return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
+    }
+}

--- a/test/ERC721DropSignatureMintImplementation/ERC721DropSignatureMintImplementation-mintSigned.ts
+++ b/test/ERC721DropSignatureMintImplementation/ERC721DropSignatureMintImplementation-mintSigned.ts
@@ -4,7 +4,7 @@ import { BigNumber, Contract } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { time } from "@nomicfoundation/hardhat-network-helpers";
 
-import type { SignedMintParamsStruct } from "../../typechain-types/src/ERC721SignatureMintImplementation";
+import type { SignedMintParamsStruct } from "../../typechain-types/src/ERC721DropSignatureMintImplementation";
 
 describe("ERC721DropSignatureMintImplementation - mintSigned", function () {
     let collection: Contract;

--- a/test/PaymentSplitterImplementation.ts
+++ b/test/PaymentSplitterImplementation.ts
@@ -1,0 +1,337 @@
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { Contract } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+describe("PaymentSplitterImplementation", function () {
+    let paymentSplitter: Contract, erc20Token: Contract;
+
+    let deployer: SignerWithAddress,
+        recipient1: SignerWithAddress,
+        recipient2: SignerWithAddress,
+        recipient3: SignerWithAddress,
+        randomUser: SignerWithAddress;
+
+    beforeEach(async function () {
+        [deployer, recipient1, recipient2, recipient3, randomUser] =
+            await ethers.getSigners();
+
+        const PaymentSplitterImplementation = await ethers.getContractFactory(
+            "PaymentSplitterImplementation",
+        );
+        paymentSplitter = await PaymentSplitterImplementation.deploy();
+        await paymentSplitter.deployed();
+
+        const TestERC20 = await ethers.getContractFactory("TestERC20");
+        erc20Token = await TestERC20.deploy();
+        await erc20Token.deployed();
+    });
+
+    describe("initialize", () => {
+        it("reverts if array of recipients or percentages are empty", async () => {
+            await expect(
+                paymentSplitter.initialize([], [4000, 6000]),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "EmptyOrMismatchedArrays",
+            );
+
+            await expect(
+                paymentSplitter.initialize(
+                    [recipient1.address, recipient2.address],
+                    [],
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "EmptyOrMismatchedArrays",
+            );
+        });
+
+        it("reverts if arrays have mismatched length", async () => {
+            await expect(
+                paymentSplitter.initialize(
+                    [recipient1.address, recipient2.address],
+                    [4000, 5000, 1000],
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "EmptyOrMismatchedArrays",
+            );
+        });
+
+        it("reverts if percentage is zero", async () => {
+            await expect(
+                paymentSplitter.initialize(
+                    [
+                        recipient1.address,
+                        recipient2.address,
+                        recipient3.address,
+                    ],
+                    [4000, 0, 6000],
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "InvalidPercentageAmount",
+            );
+        });
+
+        it("reverts if recipient is duplicate", async () => {
+            await expect(
+                paymentSplitter.initialize(
+                    [
+                        recipient1.address,
+                        recipient2.address,
+                        recipient2.address,
+                    ],
+                    [4000, 1000, 5000],
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "DuplicateRecipient",
+            );
+        });
+
+        it("reverts if sum of percentages is not equal to denominator", async () => {
+            await expect(
+                paymentSplitter.initialize(
+                    [
+                        recipient1.address,
+                        recipient2.address,
+                        recipient3.address,
+                    ],
+                    [4000, 999, 5000],
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "InvalidPercentageAmount",
+            );
+
+            await expect(
+                paymentSplitter.initialize(
+                    [
+                        recipient1.address,
+                        recipient2.address,
+                        recipient3.address,
+                    ],
+                    [4000, 1001, 5000],
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "InvalidPercentageAmount",
+            );
+        });
+
+        it("should initialize correctly if input is correct", async () => {
+            await paymentSplitter.initialize(
+                [recipient1.address, recipient2.address, recipient3.address],
+                [4000, 1000, 5000],
+            );
+
+            expect(await paymentSplitter.getRecipients()).to.deep.equal([
+                recipient1.address,
+                recipient2.address,
+                recipient3.address,
+            ]);
+        });
+    });
+
+    describe("releaseEth", () => {
+        beforeEach(async function () {
+            await paymentSplitter.initialize(
+                [recipient1.address, recipient2.address, recipient3.address],
+                [4000, 1000, 5000],
+            );
+        });
+
+        it("reverts if caller release to invalid recipient", async () => {
+            await expect(
+                paymentSplitter.releaseEth(randomUser.address),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "InvalidRecipient",
+            );
+        });
+
+        it("reverts if there is no funds to release", async () => {
+            await expect(
+                paymentSplitter.releaseEth(recipient2.address),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "NoFundsToRelease",
+            );
+        });
+
+        it("reverts if releasing for same recipient twice in row", async () => {
+            await deployer.sendTransaction({
+                to: paymentSplitter.address,
+                value: ethers.utils.parseEther("1"),
+            });
+
+            await expect(
+                paymentSplitter.releaseEth(recipient2.address),
+            ).to.changeEtherBalance(recipient2, ethers.utils.parseEther("0.1"));
+
+            await expect(
+                paymentSplitter.releaseEth(recipient2.address),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "NoFundsToRelease",
+            );
+        });
+
+        it("should release correct amount to recipients", async () => {
+            await deployer.sendTransaction({
+                to: paymentSplitter.address,
+                value: ethers.utils.parseEther("1"),
+            });
+
+            await expect(
+                paymentSplitter.releaseEth(recipient2.address),
+            ).to.changeEtherBalance(recipient2, ethers.utils.parseEther("0.1"));
+
+            // Send another 1 ETH to contract
+            await deployer.sendTransaction({
+                to: paymentSplitter.address,
+                value: ethers.utils.parseEther("1"),
+            });
+
+            await expect(
+                paymentSplitter.releaseEth(recipient2.address),
+            ).to.changeEtherBalance(recipient2, ethers.utils.parseEther("0.1"));
+
+            await expect(
+                paymentSplitter.releaseEth(recipient1.address),
+            ).to.changeEtherBalance(recipient1, ethers.utils.parseEther("0.8"));
+
+            await expect(
+                paymentSplitter.releaseEth(recipient3.address),
+            ).to.changeEtherBalance(recipient3, ethers.utils.parseEther("1"));
+
+            expect(
+                await ethers.provider.getBalance(paymentSplitter.address),
+            ).to.equal(0);
+        });
+    });
+
+    describe("releaseErc20", () => {
+        beforeEach(async function () {
+            await paymentSplitter.initialize(
+                [recipient1.address, recipient2.address, recipient3.address],
+                [4000, 1000, 5000],
+            );
+        });
+
+        it("reverts if caller release to invalid recipient", async () => {
+            await expect(
+                paymentSplitter.releaseErc20(
+                    erc20Token.address,
+                    randomUser.address,
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "InvalidRecipient",
+            );
+        });
+
+        it("reverts if there is no funds to release", async () => {
+            await expect(
+                paymentSplitter.releaseErc20(
+                    erc20Token.address,
+                    recipient2.address,
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "NoFundsToRelease",
+            );
+        });
+
+        it("reverts if releasing for same recipient twice in row", async () => {
+            await erc20Token.mint(
+                paymentSplitter.address,
+                ethers.utils.parseEther("10"),
+            );
+
+            await expect(
+                paymentSplitter.releaseErc20(
+                    erc20Token.address,
+                    recipient2.address,
+                ),
+            ).to.changeTokenBalance(
+                erc20Token,
+                recipient2,
+                ethers.utils.parseEther("1"),
+            );
+
+            await expect(
+                paymentSplitter.releaseErc20(
+                    erc20Token.address,
+                    recipient2.address,
+                ),
+            ).to.be.revertedWithCustomError(
+                paymentSplitter,
+                "NoFundsToRelease",
+            );
+        });
+
+        it("should release correct amount to recipients", async () => {
+            await erc20Token.mint(
+                paymentSplitter.address,
+                ethers.utils.parseEther("10"),
+            );
+
+            await expect(
+                paymentSplitter.releaseErc20(
+                    erc20Token.address,
+                    recipient2.address,
+                ),
+            ).to.changeTokenBalance(
+                erc20Token,
+                recipient2,
+                ethers.utils.parseEther("1"),
+            );
+
+            // Send another 10 tokens to contract
+            await erc20Token.mint(
+                paymentSplitter.address,
+                ethers.utils.parseEther("10"),
+            );
+
+            await expect(
+                paymentSplitter.releaseErc20(
+                    erc20Token.address,
+                    recipient2.address,
+                ),
+            ).to.changeTokenBalance(
+                erc20Token,
+                recipient2,
+                ethers.utils.parseEther("1"),
+            );
+
+            await expect(
+                paymentSplitter.releaseErc20(
+                    erc20Token.address,
+                    recipient1.address,
+                ),
+            ).to.changeTokenBalance(
+                erc20Token,
+                recipient1,
+                ethers.utils.parseEther("8"),
+            );
+
+            await expect(
+                paymentSplitter.releaseErc20(
+                    erc20Token.address,
+                    recipient3.address,
+                ),
+            ).to.changeTokenBalance(
+                erc20Token,
+                recipient3,
+                ethers.utils.parseEther("10"),
+            );
+
+            expect(
+                await erc20Token.balanceOf(paymentSplitter.address),
+            ).to.equal(0);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,7 +835,7 @@
     "@sentry/types" "5.30.0"
     tslib "^1.9.3"
 
-"@solidity-parser/parser@^0.14.0", "@solidity-parser/parser@^0.14.1":
+"@solidity-parser/parser@^0.14.0":
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.14.5.tgz#87bc3cc7b068e08195c219c91cd8ddff5ef1a804"
   integrity sha512-6dKnHZn7fg/iQATVEzqyUOyEidbn05q7YA2mQ9hC0MMXhhV3/JrsxmFSYZAcr7j1yUP700LLhTruvJ3MiQmjJg==
@@ -3840,35 +3840,32 @@ mnemonist@^0.38.0:
   dependencies:
     obliterator "^2.0.0"
 
-mocha@7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.1.2.tgz#8e40d198acf91a52ace122cd7599c9ab857b29e6"
-  integrity sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==
+mocha@10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
   dependencies:
-    ansi-colors "3.2.3"
+    ansi-colors "4.1.1"
     browser-stdout "1.3.1"
-    chokidar "3.3.0"
-    debug "3.2.6"
-    diff "3.5.0"
-    escape-string-regexp "1.0.5"
-    find-up "3.0.0"
-    glob "7.1.3"
-    growl "1.10.5"
+    chokidar "3.5.3"
+    debug "4.3.4"
+    diff "5.0.0"
+    escape-string-regexp "4.0.0"
+    find-up "5.0.0"
+    glob "7.2.0"
     he "1.2.0"
-    js-yaml "3.13.1"
-    log-symbols "3.0.0"
-    minimatch "3.0.4"
-    mkdirp "0.5.5"
-    ms "2.1.1"
-    node-environment-flags "1.0.6"
-    object.assign "4.1.0"
-    strip-json-comments "2.0.1"
-    supports-color "6.0.0"
-    which "1.3.1"
-    wide-align "1.1.3"
-    yargs "13.3.2"
-    yargs-parser "13.1.2"
-    yargs-unparser "1.6.0"
+    js-yaml "4.1.0"
+    log-symbols "4.1.0"
+    minimatch "5.0.1"
+    ms "2.1.3"
+    nanoid "3.3.3"
+    serialize-javascript "6.0.0"
+    strip-json-comments "3.1.1"
+    supports-color "8.1.1"
+    workerpool "6.2.1"
+    yargs "16.2.0"
+    yargs-parser "20.2.4"
+    yargs-unparser "2.0.0"
 
 mocha@^10.0.0:
   version "10.0.0"
@@ -4777,13 +4774,13 @@ solhint@^3.4.1:
   optionalDependencies:
     prettier "^2.8.3"
 
-solidity-coverage@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.2.tgz#bc39604ab7ce0a3fa7767b126b44191830c07813"
-  integrity sha512-cv2bWb7lOXPE9/SSleDO6czkFiMHgP4NXPj+iW9W7iEKLBk7Cj0AGBiNmGX3V1totl9wjPrT0gHmABZKZt65rQ==
+solidity-coverage@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.5.tgz#64071c3a0c06a0cecf9a7776c35f49edc961e875"
+  integrity sha512-6C6N6OV2O8FQA0FWA95FdzVH+L16HU94iFgg5wAFZ29UpLFkgNI/DRR2HotG1bC0F4gAc/OMs2BJI44Q/DYlKQ==
   dependencies:
     "@ethersproject/abi" "^5.0.9"
-    "@solidity-parser/parser" "^0.14.1"
+    "@solidity-parser/parser" "^0.16.0"
     chalk "^2.4.2"
     death "^1.1.0"
     detect-port "^1.3.0"
@@ -4794,7 +4791,7 @@ solidity-coverage@^0.8.2:
     globby "^10.0.1"
     jsonschema "^1.2.4"
     lodash "^4.17.15"
-    mocha "7.1.2"
+    mocha "10.2.0"
     node-emoji "^1.10.0"
     pify "^4.0.1"
     recursive-readdir "^2.2.2"


### PR DESCRIPTION



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced `PaymentSplitterImplementation` contract for splitting payments among multiple recipients with specified percentage allocations. Supports releasing both Ether and ERC20 tokens.
- New Feature: Added `PaymentSplitterProxy` contract that extends the OpenZeppelin `Proxy` contract, enabling upgradeability for the payment splitter implementation.
- Test: Comprehensive test suite added for `PaymentSplitterImplementation`, covering initialization, individual and bulk releases of ETH and ERC20 tokens.
- Chore: Deployment scripts for `PaymentSplitterImplementation` and `PaymentSplitterProxy` contracts have been added.
- Refactor: Updated import statement in `ERC721DropSignatureMintImplementation-mintSigned.ts` to correctly reference `SignedMintParamsStruct` type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->