### PR TITLE
Add getter function that returns split configuration of PaymentSplitter contract

### DIFF
--- a/src/PaymentSplitterImplementation.sol
+++ b/src/PaymentSplitterImplementation.sol
@@ -100,6 +100,20 @@ contract PaymentSplitterImplementation is Initializable {
         return _recipients;
     }
 
+    function getSplitConfiguration()
+        external
+        view
+        returns (address[] memory, uint256[] memory)
+    {
+        uint256[] memory percentages_ = new uint256[](_recipients.length);
+
+        for (uint256 i = 0; i < _recipients.length; ++i) {
+            percentages_[i] = percentages[_recipients[i]];
+        }
+
+        return (_recipients, percentages_);
+    }
+
     function calculateReleasableEth(
         address recipient
     ) public view returns (uint256) {

--- a/test/PaymentSplitterImplementation.ts
+++ b/test/PaymentSplitterImplementation.ts
@@ -133,6 +133,17 @@ describe("PaymentSplitterImplementation", function () {
                 recipient3.address,
             ]);
 
+            expect(await paymentSplitter.getSplitConfiguration()).to.deep.equal(
+                [
+                    [
+                        recipient1.address,
+                        recipient2.address,
+                        recipient3.address,
+                    ],
+                    [4000, 1000, 5000],
+                ],
+            );
+
             expect(
                 await paymentSplitter.percentages(recipient1.address),
             ).to.equal(4000);


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added a `getSplitConfiguration()` function to the `PaymentSplitterImplementation` contract. This feature allows users to retrieve the current split configuration, including recipient addresses and their corresponding percentages.
- Test: Extended test coverage for the new `getSplitFunction()` method in `PaymentSplitterImplementation.ts`. The tests ensure that the function correctly returns the expected split configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->